### PR TITLE
Support for python 3.6

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,3 +7,6 @@ by `PATH` into a `vendor` folder.
 
 Updating `gsub --version` to return the right version number.
 
+**Version 0.1.4:**
+
+Support for python3.6

--- a/gsub/main.py
+++ b/gsub/main.py
@@ -35,7 +35,7 @@ Commands:
 
 
 def show_version():
-    print("gsub: v0.1.3")
+    print("gsub: v0.1.4")
     raise SystemExit
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name="gsub",
     description="Replacement for git-submodule",
 
-    version="0.1.3",
+    version="0.1.4",
 
     author="Amit Upadhyay",
     author_email="code@amitu.com",
@@ -17,7 +17,7 @@ setup(
     license="BSD",
 
 
-    install_requires=["click==6.6"],
+    install_requires=["click==6.6", "six"],
 
     packages=['gsub'],
     zip_safe=True,
@@ -46,8 +46,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
-
-        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
 
         'Topic :: Software Development',
 


### PR DESCRIPTION
six is no longer bundled with default python install
